### PR TITLE
Add dynamic GraphQL query id detection

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -127,6 +127,38 @@
   /* eslint-enable */
   /* End of Dependencies */
 
+  const queryIds = {}
+
+  ;(function hookFetch () {
+    const origFetch = window.fetch
+    window.fetch = function (...args) {
+      const request = args[0]
+      const url = request instanceof Request ? request.url : request
+      let m
+      if ((m = /\/i\/api\/graphql\/([^/]+)\/Followers/.exec(url))) {
+        queryIds.followers = m[1]
+      } else if ((m = /\/i\/api\/graphql\/([^/]+)\/UserByScreenName/.exec(url))) {
+        queryIds.userByScreenName = m[1]
+      } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Favoriters/.exec(url))) {
+        queryIds.favoriters = m[1]
+      } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Retweeters/.exec(url))) {
+        queryIds.retweeters = m[1]
+      }
+      return origFetch.apply(this, args)
+    }
+  })()
+
+  function wait_for_query_id (key, timeout = 5000) {
+    return new Promise((resolve, reject) => {
+      const start = Date.now()
+      ;(function check () {
+        if (queryIds[key]) return resolve(queryIds[key])
+        if (Date.now() - start >= timeout) return reject(new Error(`Query ID for ${key} not found`))
+        setTimeout(check, 100)
+      })()
+    })
+  }
+
   let lang = document.documentElement.lang
   if (lang == 'en-US') {
     lang = 'en' // TweetDeck
@@ -393,12 +425,14 @@
   // fetch current followers
   async function fetch_followers(userName, count) {
     const paramsUserExtReq = `features=%7B%22hidden_profile_subscriptions_enabled%22%3Atrue%2C%22profile_label_improvements_pcf_label_in_post_enabled%22%3Atrue%2C%22rweb_tipjar_consumption_enabled%22%3Atrue%2C%22responsive_web_graphql_exclude_directive_enabled%22%3Atrue%2C%22verified_phone_label_enabled%22%3Afalse%2C%22subscriptions_verification_info_is_identity_verified_enabled%22%3Atrue%2C%22subscriptions_verification_info_verified_since_enabled%22%3Atrue%2C%22highlights_tweets_tab_ui_enabled%22%3Atrue%2C%22responsive_web_twitter_article_notes_tab_enabled%22%3Atrue%2C%22subscriptions_feature_can_gift_premium%22%3Atrue%2C%22creator_subscriptions_tweet_preview_api_enabled%22%3Atrue%2C%22responsive_web_graphql_skip_user_profile_image_extensions_enabled%22%3Afalse%2C%22responsive_web_graphql_timeline_navigation_enabled%22%3Atrue%2C%22longform_notetweets_inline_media_enabled%22%3Afalse%2C%22longform_notetweets_rich_text_read_enabled%22%3Afalse%2C%22communities_web_enable_tweet_community_results_fetch%22%3Afalse%2C%22tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled%22%3Afalse%2C%22responsive_web_grok_analyze_button_fetch_trends_enabled%22%3Afalse%2C%22tweet_awards_web_tipping_enabled%22%3Afalse%2C%22articles_preview_enabled%22%3Afalse%2C%22responsive_web_jetfuel_frame%22%3Afalse%2C%22responsive_web_enhance_cards_enabled%22%3Afalse%2C%22graphql_is_translatable_rweb_tweet_is_translatable_enabled%22%3Afalse%2C%22creator_subscriptions_quote_tweet_preview_enabled%22%3Afalse%2C%22standardized_nudges_misinfo%22%3Afalse%2C%22view_counts_everywhere_api_enabled%22%3Afalse%2C%22rweb_video_timestamps_enabled%22%3Afalse%2C%22responsive_web_grok_analyze_post_followups_enabled%22%3Afalse%2C%22longform_notetweets_consumption_enabled%22%3Afalse%2C%22freedom_of_speech_not_reach_fetch_enabled%22%3Afalse%2C%22responsive_web_grok_share_attachment_enabled%22%3Afalse%2C%22responsive_web_grok_image_annotation_enabled%22%3Afalse%2C%22c9s_tweet_anatomy_moderator_badge_enabled%22%3Afalse%2C%22responsive_web_grok_analysis_button_from_backend%22%3Afalse%2C%22responsive_web_edit_tweet_api_enabled%22%3Afalse%2C%22premium_content_api_read_enabled%22%3Afalse%2C%22responsive_web_twitter_article_tweet_consumption_enabled%22%3Afalse%7D%26fieldToggles%3D%7B%22withAuxiliaryUserLabels%22%3Afalse%7D`
-    const userIdResponse = await ajax.get(`https://x.com/i/api/graphql/32pL5BWe9WKeSK1MoPvFQQ/UserByScreenName?variables=%7B%22screen_name%22%3A%22${userName}%22%7D&${paramsUserExtReq}`);
+    const userByScreenNameId = await wait_for_query_id('userByScreenName')
+    const userIdResponse = await ajax.get(`https://x.com/i/api/graphql/${userByScreenNameId}/UserByScreenName?variables=%7B%22screen_name%22%3A%22${userName}%22%7D&${paramsUserExtReq}`);
     const userId = userIdResponse.data["data"]["user"]["result"]["rest_id"]
     console.log('user rest id', userId);
 
     const paramsExtREQ = `features=%7B%22profile_label_improvements_pcf_label_in_post_enabled%22%3Atrue%2C%22rweb_tipjar_consumption_enabled%22%3Atrue%2C%22responsive_web_graphql_exclude_directive_enabled%22%3Atrue%2C%22verified_phone_label_enabled%22%3Afalse%2C%22creator_subscriptions_tweet_preview_api_enabled%22%3Atrue%2C%22responsive_web_graphql_timeline_navigation_enabled%22%3Atrue%2C%22responsive_web_graphql_skip_user_profile_image_extensions_enabled%22%3Afalse%2C%22premium_content_api_read_enabled%22%3Afalse%2C%22communities_web_enable_tweet_community_results_fetch%22%3Atrue%2C%22c9s_tweet_anatomy_moderator_badge_enabled%22%3Atrue%2C%22responsive_web_grok_analyze_button_fetch_trends_enabled%22%3Afalse%2C%22responsive_web_grok_analyze_post_followups_enabled%22%3Atrue%2C%22responsive_web_jetfuel_frame%22%3Afalse%2C%22responsive_web_grok_share_attachment_enabled%22%3Atrue%2C%22articles_preview_enabled%22%3Atrue%2C%22responsive_web_edit_tweet_api_enabled%22%3Atrue%2C%22graphql_is_translatable_rweb_tweet_is_translatable_enabled%22%3Atrue%2C%22view_counts_everywhere_api_enabled%22%3Atrue%2C%22longform_notetweets_consumption_enabled%22%3Atrue%2C%22responsive_web_twitter_article_tweet_consumption_enabled%22%3Atrue%2C%22tweet_awards_web_tipping_enabled%22%3Afalse%2C%22responsive_web_grok_analysis_button_from_backend%22%3Atrue%2C%22creator_subscriptions_quote_tweet_preview_enabled%22%3Afalse%2C%22freedom_of_speech_not_reach_fetch_enabled%22%3Atrue%2C%22standardized_nudges_misinfo%22%3Atrue%2C%22tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled%22%3Atrue%2C%22rweb_video_timestamps_enabled%22%3Atrue%2C%22longform_notetweets_rich_text_read_enabled%22%3Atrue%2C%22longform_notetweets_inline_media_enabled%22%3Atrue%2C%22responsive_web_grok_image_annotation_enabled%22%3Afalse%2C%22responsive_web_enhance_cards_enabled%22%3Afalse%7D%26fieldToggles%3D%7B%22withAuxiliaryUserLabels%22%3Afalse%7D`
-    const response = await ajax.get(`https://x.com/i/api/graphql/OGScL-RC4DFMsRGOCjPR6g/Followers?variables=%7B%22userId%22%3A%22${userId}%22%2C%22count%22%3A${count}%2C%22includePromotedContent%22%3Afalse%7D&${paramsExtREQ}`);
+    const followersId = await wait_for_query_id('followers')
+    const response = await ajax.get(`https://x.com/i/api/graphql/${followersId}/Followers?variables=%7B%22userId%22%3A%22${userId}%22%2C%22count%22%3A${count}%2C%22includePromotedContent%22%3Afalse%7D&${paramsExtREQ}`);
     const data = response.data;
 
     const users = data["data"]["user"]["result"]["timeline"]["timeline"]["instructions"].reduce((acc, instruction) => {
@@ -421,7 +455,8 @@
 
   // fetch_likers and fetch_no_comment_reposters need to be merged into one function
   async function fetch_likers (tweetId) {
-    const response = await ajax.get(`https://x.com/i/api/graphql/-A3YSkEdbCV0rpHTkYZXCA/Favoriters?variables=%7B%22tweetId%22%3A%22${tweetId}%22%2C%22includePromotedContent%22%3Atrue%7D&${paramsREQ}`);
+    const favoritersId = await wait_for_query_id('favoriters')
+    const response = await ajax.get(`https://x.com/i/api/graphql/${favoritersId}/Favoriters?variables=%7B%22tweetId%22%3A%22${tweetId}%22%2C%22includePromotedContent%22%3Atrue%7D&${paramsREQ}`);
         const data = response.data;
 
         const users = data["data"]["favoriters_timeline"]["timeline"]["instructions"].reduce((acc, instruction) => {
@@ -443,7 +478,8 @@
   }
 
   async function fetch_no_comment_reposters (tweetId) {
-    const response = await ajax.get(`https://x.com/i/api/graphql/s6LwzbPawe8J04NldDYrQQ/Retweeters?variables=%7B%22tweetId%22%3A%22${tweetId}%22%2C%22includePromotedContent%22%3Atrue%7D&${paramsREQ}`);
+    const retweetersId = await wait_for_query_id('retweeters')
+    const response = await ajax.get(`https://x.com/i/api/graphql/${retweetersId}/Retweeters?variables=%7B%22tweetId%22%3A%22${tweetId}%22%2C%22includePromotedContent%22%3Atrue%7D&${paramsREQ}`);
         const data = response.data;
 
         const users = data["data"]["retweeters_timeline"]["timeline"]["instructions"].reduce((acc, instruction) => {


### PR DESCRIPTION
## Summary
- detect Followers/Favoriters/Retweeters/UserByScreenName query ids dynamically
- use captured ids when fetching followers, likers and reposts

## Testing
- `node --check index.user.js`