### PR TITLE
Fix query ID capture and retry logic

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -158,23 +158,35 @@ function p_limit(concurrency) {
 }
 const requestLimit = p_limit(2);      // two parallel X calls max
 
+function captureQueryId (url) {
+  let m
+  if ((m = /\/i\/api\/graphql\/([^/]+)\/Followers/.exec(url))) {
+    queryIds.followers = { id: m[1], feat: extractFeat(url) }
+  } else if ((m = /\/i\/api\/graphql\/([^/]+)\/UserByScreenName/.exec(url))) {
+    queryIds.userByScreenName = { id: m[1], feat: extractFeat(url) }
+  } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Favoriters/.exec(url))) {
+    queryIds.favoriters = { id: m[1], feat: extractFeat(url) }
+  } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Retweeters/.exec(url))) {
+    queryIds.retweeters = { id: m[1], feat: extractFeat(url) }
+  }
+}
+
 (function hookFetch () {
-  const origFetch = window.fetch;
+  const origFetch = window.fetch
   window.fetch = function (...args) {
-    const req = args[0];
-    const url = req instanceof Request ? req.url : req;
-    let m;
-    if ((m = /\/i\/api\/graphql\/([^/]+)\/Followers/.exec(url))) {
-      queryIds.followers        = { id: m[1], feat: extractFeat(url) };
-    } else if ((m = /\/i\/api\/graphql\/([^/]+)\/UserByScreenName/.exec(url))) {
-      queryIds.userByScreenName = { id: m[1], feat: extractFeat(url) };
-    } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Favoriters/.exec(url))) {
-      queryIds.favoriters       = { id: m[1], feat: extractFeat(url) };
-    } else if ((m = /\/i\/api\/graphql\/([^/]+)\/Retweeters/.exec(url))) {
-      queryIds.retweeters       = { id: m[1], feat: extractFeat(url) };
-    }
-    return origFetch.apply(this, args);
-  };
+    const req = args[0]
+    const url = req instanceof Request ? req.url : req
+    captureQueryId(url)
+    return origFetch.apply(this, args)
+  }
+})();
+
+(function hookXhr () {
+  const origOpen = XMLHttpRequest.prototype.open
+  XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    captureQueryId(url)
+    return origOpen.call(this, method, url, ...rest)
+  }
 })();
 
 
@@ -196,11 +208,15 @@ const requestLimit = p_limit(2);      // two parallel X calls max
           const regex = new RegExp(`"operationName":"${opName}"[\\s\\S]*?"queryId":"([^"\\s]+)"`)
           const m = regex.exec(text)
           if (m) {
-            queryIds[key] = m[1]
-            return m[1]
+            const feat = queryIds[key]?.feat || ''
+            queryIds[key] = { id: m[1], feat }
+            return queryIds[key]
           }
-        } catch {}
+        } catch (err) {
+          console.error('[TBWL] Failed to read', src, err)
+        }
       }
+      console.warn(`[TBWL] Query ID for ${key} not found in scripts`)
     } catch (e) {
       console.error('[TBWL] Failed to scrape query ID', e)
     }
@@ -213,8 +229,8 @@ const requestLimit = p_limit(2);      // two parallel X calls max
       ;(function check () {
         if (queryIds[key]) return resolve(queryIds[key])
         if (Date.now() - start >= timeout) {
-          scrape_query_id_from_scripts(key).then(id => {
-            if (id) resolve(id)
+          scrape_query_id_from_scripts(key).then(obj => {
+            if (obj) resolve(obj)
             else reject(new Error(`Query ID for ${key} not found`))
           })
           return
@@ -231,8 +247,11 @@ const requestLimit = p_limit(2);      // two parallel X calls max
       if (e.response && e.response.status === 404 && queryIds[opName]) {
         delete queryIds[opName]
         try {
-          const newId = await wait_for_query_id(opName)
-          const newUrl = url.replace(/\/i\/api\/graphql\/[^/]+/, `/i/api/graphql/${newId}`)
+          const { id, feat } = await wait_for_query_id(opName)
+          const m = /variables=([^&]+)/.exec(url) || []
+          let newUrl = `/i/api/graphql/${id}/${opName}`
+          if (m[1]) newUrl += `?variables=${m[1]}`
+          if (feat) newUrl += `${m[1] ? '&' : '?'}${feat}`
           return await ajax.get(newUrl)
         } catch {}
       }
@@ -512,6 +531,22 @@ const requestLimit = p_limit(2);      // two parallel X calls max
   function get_list_id () {
     // https://twitter.com/any/thing/lists/1234567/anything => 1234567/anything => 1234567
     return location.href.split('lists/')[1].split('/')[0]
+  }
+
+  function buildGqlUrl (key, vars) {
+    const info = queryIds[key]
+    if (!info) throw new Error(`[TBWL] Missing query ID for ${key}`)
+    const { id, feat = '' } = typeof info === 'string' ? { id: info, feat: '' } : info
+    const opNameMap = {
+      followers: 'Followers',
+      userByScreenName: 'UserByScreenName',
+      favoriters: 'Favoriters',
+      retweeters: 'Retweeters'
+    }
+    const opName = opNameMap[key]
+    if (!opName) throw new Error(`[TBWL] Unknown op ${key}`)
+    const variables = encodeURIComponent(JSON.stringify(vars))
+    return `/i/api/graphql/${id}/${opName}?variables=${variables}${feat ? '&' + feat : ''}`
   }
 
   // fetch current followers


### PR DESCRIPTION
## Summary
- hook into both fetch and XHR to record GraphQL query IDs
- rebuild retry URLs in `safeCall`

## Testing
- `node --check index.user.js`
